### PR TITLE
Publish to npm when a release is created

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This GitHub action automates the release process to npm. When this PR is merged follow the steps in the wiki page I've created to do an npm release:
https://github.com/ngnijland/typescript-todo-or-die-plugin/wiki

This is untested, as we do not have changes ready to do a release. I used this documentation to implement this:
https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages