### PR TITLE
feat: support FIXME and custom tags

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,11 @@ function init(modules: {
         ) => {
           const newLineLength = acc.characterCount + lineLength;
 
-          const validation = validateTodo(text, info.config?.options);
+          const validation = validateTodo({
+            todo: text,
+            options: info.config?.options,
+            additionalKeywords: info.config?.additionalKeywords,
+          });
 
           if (!validation.error) {
             return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,3 +22,9 @@ export type ConfigOptions = {
 export type Validation = DiagnosticError | DiagnosticApproval;
 
 export type Periods = { w: number; d: number; h: number };
+
+export type ValidateTodo = {
+  additionalKeywords?: string[];
+  options?: ConfigOptions;
+  todo: string;
+};

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,40 +1,46 @@
-import { isValidDate, isValidWarnOption, parseWarnOption , getWarningPeriod } from './utils'
+import {
+  getWarningPeriod,
+  isValidDate,
+  isValidWarnOption,
+  parseWarnOption,
+  startsWithKeyword,
+} from "./utils";
 
 test("isValidDate", () => {
-  const date = "2021-12-05"
-  const res = isValidDate(date)
+  const date = "2021-12-05";
+  const res = isValidDate(date);
 
-  expect(res).toBe(true)
-})
+  expect(res).toBe(true);
+});
 
 test("isValidDate invalidates wrong format", () => {
-  const date = "20-06-2021"
-  const res = isValidDate(date)
+  const date = "20-06-2021";
+  const res = isValidDate(date);
 
-  expect(res).toBe(false)
-})
+  expect(res).toBe(false);
+});
 
 test("isValidDate invalidates no format", () => {
-  const date = "20062021"
-  const res = isValidDate(date)
+  const date = "20062021";
+  const res = isValidDate(date);
 
-  expect(res).toBe(false)
-})
+  expect(res).toBe(false);
+});
 
 test("isValidDate invalidates empty", () => {
-  const date = ""
-  const res = isValidDate(date)
+  const date = "";
+  const res = isValidDate(date);
 
-  expect(res).toBe(false)
-})
+  expect(res).toBe(false);
+});
 
 test("isValidWarnOption validates", () => {
-  const validWeeks = '1w'
-  const validDays = '20d'
-  const validHours = '24h'
-  const resultW = isValidWarnOption(validWeeks)
-  const resultD = isValidWarnOption(validDays)
-  const resultH = isValidWarnOption(validHours)
+  const validWeeks = "1w";
+  const validDays = "20d";
+  const validHours = "24h";
+  const resultW = isValidWarnOption(validWeeks);
+  const resultD = isValidWarnOption(validDays);
+  const resultH = isValidWarnOption(validHours);
 
   expect(resultW).toBe(validWeeks);
   expect(resultD).toBe(validDays);
@@ -42,12 +48,12 @@ test("isValidWarnOption validates", () => {
 });
 
 test("isValidWarnOption invalidates", () => {
-  const invalid1 = 'rew'
-  const invalid2 = ''
-  const invalid3 = '20g'
-  const result1 = isValidWarnOption(invalid1)
-  const result2 = isValidWarnOption(invalid2)
-  const result3 = isValidWarnOption(invalid3)
+  const invalid1 = "rew";
+  const invalid2 = "";
+  const invalid3 = "20g";
+  const result1 = isValidWarnOption(invalid1);
+  const result2 = isValidWarnOption(invalid2);
+  const result3 = isValidWarnOption(invalid3);
 
   expect(result1).toBe(false);
   expect(result2).toBe(false);
@@ -55,31 +61,52 @@ test("isValidWarnOption invalidates", () => {
 });
 
 test("parseWarnOption", () => {
-  const opt = '23h'
-  const [multipler, interval] = parseWarnOption(opt)
+  const opt = "23h";
+  const [multipler, interval] = parseWarnOption(opt);
 
-  expect(multipler).toBe(23)
-  expect(interval).toBe('h')
-})
+  expect(multipler).toBe(23);
+  expect(interval).toBe("h");
+});
 
 test("parseWarnOption with wrong option", () => {
-  const opt = '5x'
-  const [multipler, interval] = parseWarnOption(opt)
+  const opt = "5x";
+  const [multipler, interval] = parseWarnOption(opt);
 
-  expect(multipler).toBe(1)
-  expect(interval).toBe('w')
-})
+  expect(multipler).toBe(1);
+  expect(interval).toBe("w");
+});
 
 test("getWarningPeriod with true", () => {
-  const option = true
-  const res = getWarningPeriod(option)
+  const option = true;
+  const res = getWarningPeriod(option);
 
-  expect(res).toBe(604800)
-})
+  expect(res).toBe(604800);
+});
 
 test("getWarningPeriod with interval option", () => {
-  const option = '1h'
-  const res = getWarningPeriod(option)
+  const option = "1h";
+  const res = getWarningPeriod(option);
 
-  expect(res).toBe(3600)
-})
+  expect(res).toBe(3600);
+});
+
+test("startsWithKeyword returns true on lines that start with keywords", () => {
+  const keywords = ["TODO", "FIXME"];
+
+  const validLine1 = "// TODO::after_date('2020-01-01'): fix me";
+  const validLine2 = "// FIXME::after_date('2020-01-01'): fix me";
+
+  const res1 = startsWithKeyword(validLine1, keywords);
+  const res2 = startsWithKeyword(validLine2, keywords);
+
+  expect(res1).toBe(true);
+  expect(res2).toBe(true);
+});
+
+test("startsWithKeyword returns false on lines that don't start with keywords", () => {
+  const keywords = ["TODO", "FIXME"];
+  const invalidLine = "// NOTAVALIDKEYWORD::after_date('2020-01-01'): fix me";
+  const res = startsWithKeyword(invalidLine, keywords);
+
+  expect(res).toBe(false);
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,9 +10,9 @@ export const isValidDate = (date: string): boolean => {
   //const regex = new RegExp(/^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$/)
 
   //return regex.test(date)
-  const [year] = date.split('-')
-  return year.length === 4
-}
+  const [year] = date.split("-");
+  return year.length === 4;
+};
 
 export const isValidWarnOption = (option: string): string | boolean => {
   return option.match(/^\d+[w|d|h]$/) ? option : false;
@@ -39,4 +39,11 @@ export const getWarningPeriod = (warnOption: string | true): number => {
   return multipler * periods[interval];
 };
 
-
+export const startsWithKeyword = (
+  todo: string,
+  keywords: string[]
+): boolean => {
+  return keywords.some((keyword) => {
+    return todo.startsWith(`// ${keyword}::`);
+  });
+};

--- a/src/validateTodo.ts
+++ b/src/validateTodo.ts
@@ -1,29 +1,36 @@
-import { Validation, ConfigOptions, Conditions } from './types'
-import { after_date } from './after_date';
+import { Validation, ValidateTodo, Conditions } from "./types";
+import { after_date } from "./after_date";
+import { startsWithKeyword } from "./utils";
 
 const conditions: Conditions = {
   after_date,
 };
 
-export function validateTodo(
-  todo: string,
-  options?: ConfigOptions
-): Validation {
-  if (!todo.startsWith("// TODO::")) {
-    return {
-      error: false,
-    };
-  }
+export function validateTodo({
+  additionalKeywords,
+  options,
+  todo,
+}: ValidateTodo): Validation {
+  const keywords = [
+    "TODO",
+    "FIXME",
+    ...(additionalKeywords ? additionalKeywords : []),
+  ];
 
-  const condition = todo.substring(
-    todo.indexOf("::") + 2,
-    todo.lastIndexOf(":")
-  );
+  if (startsWithKeyword(todo, keywords)) {
+    const condition = todo.substring(
+      todo.indexOf("::") + 2,
+      todo.lastIndexOf(":")
+    );
 
-  if (condition.startsWith("after_date")) {
-    const param = todo.substring(todo.indexOf("(") + 2, todo.lastIndexOf(")"));
+    if (condition.startsWith("after_date")) {
+      const param = todo.substring(
+        todo.indexOf("(") + 2,
+        todo.lastIndexOf(")")
+      );
 
-    return conditions.after_date(param, options);
+      return conditions.after_date(param, options);
+    }
   }
 
   return { error: false };


### PR DESCRIPTION
## What's in the PR:
- Adds a `FIXME` keyword by default (next to `TODO`)
- Allow additional keywords to be added via the config
- Tests for the new `startsWithKeyword` util
- Linting 😛 
- Closes #10 

## Custom keywords example
```JSON
"plugins": [{
  "name": "typescript-todo-or-die-plugin",
  "additionalKeywords": ["FIX", "ANOTHERONE"]
}]
```
## Example
<img width="519" alt="Screenshot 2021-10-08 at 20 00 53" src="https://user-images.githubusercontent.com/6746411/136602230-00045124-115b-4291-ae9b-097d5ba53055.png">
s
