### PR TITLE
ci: rename release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The release job in the release action was called `build` since I copied it from an example node action (https://github.com/ngnijland/typescript-todo-or-die-plugin/actions/runs/1340492241). I renamed it to `release`.